### PR TITLE
Observer refactor Step 1: SO event channel scaffolding

### DIFF
--- a/Assets/Scripts/Events/EventChannelSO.cs
+++ b/Assets/Scripts/Events/EventChannelSO.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+
+public abstract class EventChannelSO<T> : ScriptableObject
+{
+    public event Action<T> OnRaised;
+    public T LastValue { get; private set; }
+    public bool HasValue { get; private set; }
+
+    public void Raise(T payload)
+    {
+        LastValue = payload;
+        HasValue = true;
+        OnRaised?.Invoke(payload);
+    }
+
+    void OnDisable()
+    {
+        // Clear subscribers and replay state on Play Mode exit (§6.5).
+        OnRaised = null;
+        HasValue = false;
+        LastValue = default;
+    }
+}

--- a/Assets/Scripts/Events/VoidEventChannelSO.cs
+++ b/Assets/Scripts/Events/VoidEventChannelSO.cs
@@ -1,0 +1,15 @@
+using System;
+using UnityEngine;
+
+public abstract class VoidEventChannelSO : ScriptableObject
+{
+    public event Action OnRaised;
+
+    public void Raise() => OnRaised?.Invoke();
+
+    void OnDisable()
+    {
+        // Clear subscribers on Play Mode exit so they don't leak when Domain Reload is disabled (§6.5).
+        OnRaised = null;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `VoidEventChannelSO` and `EventChannelSO<T>` abstract base types under `Assets/Scripts/Events/`.
- Establishes the foundation for the project-wide Observer Pattern refactor — concrete channels (Fuel, GameState, Score, etc.) will subclass these in later PRs.
- Both bases clear subscribers and replay state in `OnDisable` so they don't leak across Play Mode reloads when Domain Reload is disabled.
- `EventChannelSO<T>` exposes `LastValue` / `HasValue` for late-subscribed listeners to replay the last broadcast on `OnEnable`.

## Why
First step of the Observer refactor plan agreed on this branch. Decouples gameplay producers (Fuel, Player, Enemy, Lever) from consumers (UI, Audio, VFX, GameController) without forcing every event onto a single mechanism. See plan: §5 (scaffolding) and §6 (lifecycle / replay / leak rules).

## Reviewer notes
- No behavioral change yet — these are abstract bases with no concrete subclasses or assets.
- Nothing else compiles against these types yet, so this PR is safe to merge or sit until Step 2 lands.
- Unity should generate `.meta` files on next focus; commit those in a follow-up if needed.

## Test plan
- [ ] Open Unity, confirm no compile errors after the new files import.
- [ ] Confirm `.meta` files generate under `Assets/Scripts/Events/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)