### PR TITLE
Observer refactor: Unity meta files for event channel scaffolding

### DIFF
--- a/Assets/Scripts/Events.meta
+++ b/Assets/Scripts/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec92152072939440697df1d9c1bbf881
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Events/EventChannelSO.cs.meta
+++ b/Assets/Scripts/Events/EventChannelSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 59b64844120f045708d5e8e7e7cc75b0

--- a/Assets/Scripts/Events/VoidEventChannelSO.cs.meta
+++ b/Assets/Scripts/Events/VoidEventChannelSO.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 167c5bcd4947c4729bb308723626a0ef


### PR DESCRIPTION
## Summary
Follow-up to #20. Adds the Unity-generated `.meta` files that #20 missed:
- `Assets/Scripts/Events.meta` (folder meta)
- `Assets/Scripts/Events/EventChannelSO.cs.meta`
- `Assets/Scripts/Events/VoidEventChannelSO.cs.meta`

## Why
Unity meta files carry the GUIDs that prefabs and scenes reference. If they aren't checked in, every contributor's Unity regenerates fresh GUIDs on import and breaks any references to these scripts. They were generated locally but not included in the original scaffolding PR.

## Test plan
- [ ] Open Unity, confirm no `[Reimport]` warnings about missing meta files.
- [ ] Confirm GUIDs match what Unity already imported locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)