### PR TITLE
Observer refactor Steps 2+3: Fuel pipeline on event channels

### DIFF
--- a/Assets/Scripts/DavidPocScripts/Fuel.cs
+++ b/Assets/Scripts/DavidPocScripts/Fuel.cs
@@ -5,6 +5,7 @@ public class Fuel : MonoBehaviour
 {
     [SerializeField] private string playerTag = "Player";
     [SerializeField] private GameObject pickupVFXPrefab;
+    [SerializeField] private FuelCollectedChannel fuelCollectedChannel;
 
     void Reset()
     {
@@ -16,8 +17,10 @@ public class Fuel : MonoBehaviour
     {
         if (!other.CompareTag(playerTag)) return;
 
-        GameManager gm = GameManager.Instance;
-        if (gm != null) gm.CollectFuel();
+        if (fuelCollectedChannel != null)
+            fuelCollectedChannel.Raise();
+        else
+            Debug.LogWarning("Fuel: no FuelCollectedChannel assigned; pickup will not register.", this);
 
         if (pickupVFXPrefab != null)
             Instantiate(pickupVFXPrefab, transform.position, Quaternion.identity);

--- a/Assets/Scripts/DavidPocScripts/FuelUI.cs
+++ b/Assets/Scripts/DavidPocScripts/FuelUI.cs
@@ -6,30 +6,35 @@ public class FuelUI : MonoBehaviour
 {
     [SerializeField] private TextMeshProUGUI fuelText;
     [SerializeField] private Slider fuelSlider;
+    [SerializeField] private FuelStateChannel fuelState;
 
-    void Start()
+    void OnEnable()
     {
-        if (GameManager.Instance == null)
+        if (fuelState == null)
         {
-            Debug.LogWarning("FuelUI: no GameManager in scene.");
+            Debug.LogWarning("FuelUI: no FuelStateChannel assigned.", this);
             return;
         }
 
         if (fuelText == null && fuelSlider == null)
-            Debug.LogWarning("FuelUI has no Text or Slider assigned.");
+            Debug.LogWarning("FuelUI has no Text or Slider assigned.", this);
 
-        GameManager.Instance.FuelChanged += OnFuelChanged;
-        OnFuelChanged(GameManager.Instance.FuelCollected, GameManager.Instance.FuelTarget);
+        fuelState.OnRaised += OnFuelChanged;
+
+        if (fuelState.HasValue)
+            OnFuelChanged(fuelState.LastValue);
     }
 
-    void OnDestroy()
+    void OnDisable()
     {
-        if (GameManager.Instance != null)
-            GameManager.Instance.FuelChanged -= OnFuelChanged;
+        if (fuelState != null)
+            fuelState.OnRaised -= OnFuelChanged;
     }
 
-    void OnFuelChanged(int collected, int target)
+    void OnFuelChanged((int collected, int target) state)
     {
+        var (collected, target) = state;
+
         if (fuelText != null)
             fuelText.text = $"Fuel: {collected}/{target}";
 

--- a/Assets/Scripts/DavidPocScripts/GameManager.cs
+++ b/Assets/Scripts/DavidPocScripts/GameManager.cs
@@ -1,4 +1,3 @@
-using System;
 using UnityEngine;
 
 public class GameManager : MonoBehaviour
@@ -8,10 +7,9 @@ public class GameManager : MonoBehaviour
     [SerializeField] private int fuelTarget = 4;
     [SerializeField] private int fuelCollected = 0;
 
-    public event Action<int, int> FuelChanged;
+    [SerializeField] private FuelCollectedChannel fuelCollectedChannel;
+    [SerializeField] private FuelStateChannel fuelStateChannel;
 
-    public int FuelCollected => fuelCollected;
-    public int FuelTarget => fuelTarget;
     public bool IsFullyFueled => fuelCollected >= fuelTarget;
 
     void Awake()
@@ -24,15 +22,33 @@ public class GameManager : MonoBehaviour
         Instance = this;
     }
 
-    void Start()
+    void OnEnable()
     {
-        FuelChanged?.Invoke(fuelCollected, fuelTarget);
+        if (fuelCollectedChannel != null)
+            fuelCollectedChannel.OnRaised += HandleFuelCollected;
     }
 
-    public void CollectFuel()
+    void OnDisable()
+    {
+        if (fuelCollectedChannel != null)
+            fuelCollectedChannel.OnRaised -= HandleFuelCollected;
+    }
+
+    void Start()
+    {
+        RaiseState();
+    }
+
+    void HandleFuelCollected()
     {
         fuelCollected = Mathf.Min(fuelCollected + 1, fuelTarget);
         Debug.Log($"Fuel: {fuelCollected}/{fuelTarget}");
-        FuelChanged?.Invoke(fuelCollected, fuelTarget);
+        RaiseState();
+    }
+
+    void RaiseState()
+    {
+        if (fuelStateChannel != null)
+            fuelStateChannel.Raise((fuelCollected, fuelTarget));
     }
 }

--- a/Assets/Scripts/Events/FuelCollectedChannel.cs
+++ b/Assets/Scripts/Events/FuelCollectedChannel.cs
@@ -1,0 +1,4 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Events/Fuel Collected Channel")]
+public class FuelCollectedChannel : VoidEventChannelSO { }

--- a/Assets/Scripts/Events/FuelCollectedChannel.cs.meta
+++ b/Assets/Scripts/Events/FuelCollectedChannel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c861ac1312b34e2fab4bf134f1d12447

--- a/Assets/Scripts/Events/FuelStateChannel.cs
+++ b/Assets/Scripts/Events/FuelStateChannel.cs
@@ -1,0 +1,4 @@
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Events/Fuel State Channel")]
+public class FuelStateChannel : EventChannelSO<(int collected, int target)> { }

--- a/Assets/Scripts/Events/FuelStateChannel.cs.meta
+++ b/Assets/Scripts/Events/FuelStateChannel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0c2dbf4cb5d248a28ca5b0101b0bd950


### PR DESCRIPTION
## Summary
Migrates the fuel pickup pipeline off the `GameManager.Instance` singleton path and onto SO event channels.

**New channel assets** (`Assets/Scripts/Events/`):
- `FuelCollectedChannel` (void) — raised when a fuel pickup is collected.
- `FuelStateChannel` (`(int collected, int target)`) — raised whenever the fuel count changes; carries the new totals.

**Producer changes:**
- `Fuel.OnTriggerEnter` → raises `FuelCollectedChannel.Raise()` instead of calling `GameManager.Instance.CollectFuel()`.
- `GameManager` now subscribes to `FuelCollectedChannel` in `OnEnable`, increments its counter in the handler, and raises `FuelStateChannel` with the new `(collected, target)` tuple.

**Consumer changes (B1 hygiene fix bundled):**
- `FuelUI` subscribes to `FuelStateChannel` in `OnEnable` and unsubscribes in `OnDisable` (was `Start`/`OnDestroy`).
- Uses `fuelState.LastValue` for the initial-state replay, removing the last `GameManager.Instance` reference from `FuelUI`.

## Why
First real refactor on top of the Step 1 scaffolding. Demonstrates the SO-channel pattern on an isolated, high-value pipeline (Fuel) before extending it elsewhere. After this PR, Fuel pickups, GameManager state, and FuelUI display are fully decoupled — each side can be tested and reused independently. Reference: plan §4.A.A1 and §4.B.B1.

## ⚠️ Scene re-wiring required (designer step)
Existing scenes still reference these scripts but their new `[SerializeField]` channel slots are empty. To make this run:

1. In the Project view, right-click `Assets/Events/` (create the folder if it doesn't exist) → **Create → Events → Fuel Collected Channel**, name it `FuelCollected.channel.asset`.
2. Same menu → **Create → Events → Fuel State Channel**, name it `FuelState.channel.asset`.
3. Open `DavidL1Sandbox.unity` (and any other scene with Fuel/GameManager/FuelUI):
   - Select each `Fuel` pickup → drag `FuelCollected.channel.asset` into the **Fuel Collected Channel** slot.
   - Select the `GameManager` GameObject → drag `FuelCollected.channel.asset` into **Fuel Collected Channel** and `FuelState.channel.asset` into **Fuel State Channel**.
   - Select the `FuelUI` GameObject → drag `FuelState.channel.asset` into the **Fuel State** slot.

Without these references, the console will warn `"Fuel: no FuelCollectedChannel assigned"` or `"FuelUI: no FuelStateChannel assigned"` and the pipeline won't function — that's the intended fail-loud behavior.

## API removed
- `GameManager.CollectFuel()` — replaced by the channel-driven handler.
- `GameManager.FuelChanged` event — replaced by `FuelStateChannel`.
- `GameManager.FuelCollected` / `FuelTarget` getters — only consumer was `FuelUI`, which now reads `LastValue`.

`GameManager.IsFullyFueled` is preserved because `ShipTrigger` still reads it; that coupling is removed in Step 4.

## Test plan
- [ ] Open `DavidL1Sandbox.unity`, create the two channel assets, re-wire the three components per the steps above.
- [ ] Walk into a fuel pickup → confirm HUD updates and console logs `Fuel: 1/4`.
- [ ] Reload the scene → confirm no duplicate-handler logs (FuelUI's `OnDisable` runs first).
- [ ] Disable the FuelUI GameObject mid-play, then re-enable → confirm the HUD repopulates immediately from `LastValue`.
- [ ] Verify `grep -rn "GameManager.Instance" Assets/Scripts/DavidPocScripts/FuelUI.cs Assets/Scripts/DavidPocScripts/Fuel.cs` returns no hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)